### PR TITLE
Exit if an invalid configuration is detected

### DIFF
--- a/kmd-logic-digitalpost-console-sample/Configuration.cs
+++ b/kmd-logic-digitalpost-console-sample/Configuration.cs
@@ -27,7 +27,7 @@ namespace Kmd.Logic.Digitalpost.ConsoleSample
 
     class LogicDigitalPostConfiguration
     {
-        public int SystemId { get; set; }
-        public int MaterialId { get; set; }        
+        public int? SystemId { get; set; }
+        public int? MaterialId { get; set; }        
     }
 }


### PR DESCRIPTION
Fixes #1 

If this change is merged, the user will see this on the first run:

![image](https://user-images.githubusercontent.com/570470/50620686-a3b52680-0f4c-11e9-99ee-f971c97c96e7.png)

After filling in the logic account, the user will see this:
![image](https://user-images.githubusercontent.com/570470/50620737-f0006680-0f4c-11e9-8560-bd2dd540c509.png)
